### PR TITLE
Fix nav flickering in Safari browser

### DIFF
--- a/css/_nav.scss
+++ b/css/_nav.scss
@@ -6,6 +6,7 @@
     @include media-breakpoint-up($break) {
       .ctrl {
         width: $max-width*(3/$grid-columns);
+        max-width: $max-width*(3/$grid-columns);
       }
       .ctrl.open,
       .ctrl:hover {


### PR DESCRIPTION
Previously the nav would flicker when hovering out due to the max-width
transitioning from `max-width: $max-width*(6/$grid-columns);` to an
undefined `max-width`. This only seems to be noticeable in Safari, but
was quite bothersome!

Adding a default `max-width` fixes the issue.
