### PR TITLE
Prevent dispatching in the middle of a dispatch

### DIFF
--- a/js/stores/TreeStore.coffee
+++ b/js/stores/TreeStore.coffee
@@ -168,7 +168,10 @@ TreeStore.dispatchToken = MessageDispatcher.register (p) ->
   a = p.action
 
   if TreeStore[a.type]
-    TreeStore[a.type] a
-    TreeStore.emitChange()
+    # Prevent dispatching in the middle of a dispatch
+    setTimeout ->
+      TreeStore[a.type] a
+      TreeStore.emitChange()
+    , 0
 
 module.exports = TreeStore


### PR DESCRIPTION
Previously unmounting an urbit app module from within tree by, for
example, hitting the back button, would cause a dispatch to be emitted
durring another dispatch, which would throw an exception.

The official method for handling this is to use the
dispatchToken.waitFor method. However that requires referencing a
specific dispatchToken to wait for, which was causing circular
dependencies. So the setTimeout method, works, albeit a bit hacky.

issue #14
