### PR TITLE
Remove ~.main_urb.js instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,12 +53,3 @@ If you have a patch you'd like to contribute:
 # Distribution
 
 Compiled `main.js` and `main.css` get periodically shipped to the [urbit core](http://github.com/urbit/urbit).  Each time these compiled files are moved to urbit core their commit message should contain the sha-1 of the commit from this repo.  
-
-As a performance optimization, they are bundled with dependant `js` and `css` respectively: after copying `desk/` over into `arvo/`,
-
-```
-cat web/{tree/main,lib/js/urb}.js >web/tree/~.main_urb.js
-cat web/{lib/css/{codemirror,fonts,bootstrap},tree/main}.css >web/tree/~.codemirror_fonts_bootstrap_main.css
-```
-
-to ensure the latest version is available without `?dbg.nopack`.


### PR DESCRIPTION
After urbit/arvo#160 is merged, this will no longer be necessary.
