### PR TITLE
Moon name shortening

### DIFF
--- a/js/utils/util.coffee
+++ b/js/utils/util.coffee
@@ -22,6 +22,8 @@ module.exports =
   shortShip: (ship=urb.user)->
     if ship.length <= 13
       ship
+    else if ship.length == 27
+      ship[14...20] + "^" + ship[-6...]
     else
       ship[0...6] + "_" + ship[-6...] # s/(.{6}).*(.{6})/\1_\2/
 


### PR DESCRIPTION
`util.shortShip` was handeling everything longer than a planet name as a comet, resulting in incorrect names for moons. It now properly takes the last four syllables when a moon name is being shortened.
(Solves https://github.com/urbit/talk/issues/25)
