### PR TITLE
REPL Component

### DIFF
--- a/css/_repl.scss
+++ b/css/_repl.scss
@@ -1,0 +1,15 @@
+.CodeMirror {
+  height: auto;
+  border: 1px solid #eee;
+}
+.CodeMirror-scroll {
+  height: auto;
+  overflow-y: hidden;
+  overflow-x: auto;
+}
+.repl {
+  width: auto
+}
+.error {
+  background: #ebb
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -15,3 +15,4 @@
 @import "post";
 @import "sections";
 @import "comments";
+@import "repl";

--- a/js/components/Components.coffee
+++ b/js/components/Components.coffee
@@ -3,6 +3,7 @@ recl       = React.createClass
 
 module.exports =
   codemirror: require './CodeMirror.coffee'
+  repl:       require './Repl.coffee'
   search:     require './SearchComponent.coffee'
   list:       require './ListComponent.coffee'
   kids:       require './KidsComponent.coffee'

--- a/js/components/Repl.coffee
+++ b/js/components/Repl.coffee
@@ -21,8 +21,8 @@ module.exports = recl
       lineNumbers: true
       extraKeys:
         Enter: @cmSend
+        Tab: @betterTab
       tabSize: 2
-      indentWithTabs: false
   setRef: (ref) ->
     @ta = ref
   cleanseUrl: (str) ->
@@ -74,3 +74,8 @@ module.exports = recl
       showOutput: false
       alertClass: 'alert-info'
     return
+  betterTab: (cm) ->
+    if cm.somethingSelected()
+      cm.indentSelection("add")
+    else
+      cm.execCommand("insertSoftTab")

--- a/js/components/Repl.coffee
+++ b/js/components/Repl.coffee
@@ -1,18 +1,20 @@
 recl = React.createClass
-{div,textarea,pre} = React.DOM
+{div,textarea,pre,br} = React.DOM
 
 module.exports = recl
   render: ->
     preNode = pre({ className: 'alert ' + @state.alertClass }, @state.output)
     emptyNode = pre({ className: 'alert' + @state.alertClass, hidden: true })
     partial = if @state.showOutput then preNode else emptyNode
-    div {}, textarea(ref: @setRef), partial
+    div {}, textarea(value: @props.value, ref: @setRef), partial, br {}
   componentDidMount: ->
     CodeMirror.fromTextArea(ReactDOM.findDOMNode(@ta), @state.options)
-  getInitialState: ->
-    input: ''
-    output: ''
+  getDefaultProps:  ->
     solution: ''
+    value: ''
+  getInitialState: ->
+    value: ''
+    output: ''
     showOutput: false
     alertClass: 'alert-info'
     options:
@@ -37,11 +39,11 @@ module.exports = recl
       return
     ).join ''
   cmSend: (cm) ->
-    input = cm.getValue()
-    if input == ''
+    value = cm.getValue()
+    if value == ''
       @hideOutput()
       return
-    @send input, @renderOutput
+    @send value, @renderOutput
     return
   send: (str, cb) ->
     $.ajax(url: '/.repl-json?eval=' + @cleanseUrl(str)).then cb
@@ -49,10 +51,16 @@ module.exports = recl
   renderOutput: (res) ->
     switch Object.keys(res).join(' ')
       when 'good'
-        @setState
-          output: res.good
-          showOutput: true
-          alertClass: 'alert-info'
+        if res.good == @props.solution
+          @setState
+            output: res.good
+            showOutput: true
+            alertClass: 'alert-success'
+        else
+          @setState
+            output: res.good
+            showOutput: true
+            alertClass: 'alert-info'
       when 'bad'
         @setState
           output: res.bad

--- a/js/components/Repl.coffee
+++ b/js/components/Repl.coffee
@@ -1,0 +1,68 @@
+recl = React.createClass
+{div,textarea,pre} = React.DOM
+
+module.exports = recl
+  render: ->
+    preNode = pre({ className: 'alert ' + @state.alertClass }, @state.output)
+    emptyNode = pre({ className: 'alert' + @state.alertClass, hidden: true })
+    partial = if @state.showOutput then preNode else emptyNode
+    div {}, textarea(ref: @setRef), partial
+  componentDidMount: ->
+    CodeMirror.fromTextArea(ReactDOM.findDOMNode(@ta), @state.options)
+  getInitialState: ->
+    input: ''
+    output: ''
+    solution: ''
+    showOutput: false
+    alertClass: 'alert-info'
+    options:
+      lineNumbers: true
+      extraKeys:
+        Enter: @cmSend
+      tabSize: 2
+      indentWithTabs: false
+  setRef: (ref) ->
+    @ta = ref
+  cleanseUrl: (str) ->
+    hex = '0123456789ABCDEF'
+    [].map.call(str, (c) ->
+      switch true
+        when /[a-z0-9._~]/.test(c)
+          return c
+        when /[ -~]/.test(c)
+          n = c.charCodeAt(0)
+          return '%' + hex[n / 16 | 0] + hex[n % 16]
+        else
+          return encodeURIComponent(c)
+      return
+    ).join ''
+  cmSend: (cm) ->
+    input = cm.getValue()
+    if input == ''
+      @hideOutput()
+      return
+    @send input, @renderOutput
+    return
+  send: (str, cb) ->
+    $.ajax(url: '/.repl-json?eval=' + @cleanseUrl(str)).then cb
+    return
+  renderOutput: (res) ->
+    switch Object.keys(res).join(' ')
+      when 'good'
+        @setState
+          output: res.good
+          showOutput: true
+          alertClass: 'alert-info'
+      when 'bad'
+        @setState
+          output: res.bad
+          showOutput: true
+          alertClass: 'alert-danger'
+      else
+        throw new Error('Unknown result: ' + Object.keys(res))
+    return
+  hideOutput: ->
+    @setState
+      showOutput: false
+      alertClass: 'alert-info'
+    return


### PR DESCRIPTION
Implemented a self-contained REPL component so users can render multiple on the same page. This will be used for the [Loon (Learn Hoon)](https://github.com/mattlevan/loon) course.

Illustration:
![image](https://user-images.githubusercontent.com/4582375/34280300-b402fab8-e66b-11e7-886f-76bbcf2095c6.png)

Corresponding Sail:
```
;repl;
;repl(value "|1:[42 43 44]");
;repl(solution "45", value "[42 43 44 45]");
```

@ohAitch how can we insert multiple line default values?

Could be later extended to support:
- Hoon syntax highlighting using @philipcmonk's CodeMirror Hoon mode
- Udon editing
- Use for Clay file editing from web

This component is far from pure, I think, and I don't know React hardly at all, so let me know if I should go back and implement this in a more functional style. 

Also, I know Tree will be (is?) undergoing some heavy refactoring by Isaac and others. I'm sure I had his GitHub username around here somewhere... I'd appreciate a link to his account. 